### PR TITLE
configure rust-tools and nvim-cmp

### DIFF
--- a/_vimrc
+++ b/_vimrc
@@ -35,6 +35,13 @@ call plug#begin('~/.vim/plugged')
     Plug 'https://github.com/neovim/nvim-lspconfig'
     Plug 'https://github.com/kyazdani42/nvim-tree.lua'
     Plug 'https://github.com/ggandor/leap.nvim', {'branch': 'main'}
+    Plug 'https://github.com/hrsh7th/nvim-cmp', {'branch': 'main'}
+    Plug 'https://github.com/hrsh7th/cmp-nvim-lsp', {'branch': 'main'}
+    Plug 'https://github.com/saadparwaiz1/cmp_luasnip'
+    Plug 'https://github.com/L3MON4D3/LuaSnip', {'tag': '*'}
+
+    " Rust
+    Plug 'https://github.com/simrat39/rust-tools.nvim'
 
     " Markdown
     Plug 'https://github.com/iamcco/markdown-preview.nvim', {'do': 'cd app && yarn install'}

--- a/lua/vimrc_lua_config.lua
+++ b/lua/vimrc_lua_config.lua
@@ -1,3 +1,12 @@
+-- general
+vim.o.ch = 0
+
+-- nvim-colorizer
+require'colorizer'.setup()
+
+-- leap
+require('leap').set_default_keymaps()
+
 -- nvim-tree
 vim.opt.termguicolors = true
 
@@ -33,14 +42,39 @@ require("nvim-tree").setup({
   },
 })
 
--- nvim-colorizer
-require'colorizer'.setup()
-
 -- nvim-tree-sitter
 require'nvim-treesitter.configs'.setup({
-    ensure_installed = { "ruby", "javascript", "typescript", "lua", "rust", "toml" },
-    highlight = { enable = true, additional_vim_regex_highlighting = false, },
-  })
+  ensure_installed = { "ruby", "javascript", "typescript", "lua", "rust", "toml" },
+  highlight = { enable = true, additional_vim_regex_highlighting = false, },
+})
+
+-- cmp
+vim.o.completeopt="menu,menuone,noselect"
+
+-- https://github.com/hrsh7th/nvim-cmp/wiki/Language-Server-Specific-Samples#rust-with-rust-toolsnvim
+local cmp = require'cmp'
+cmp.setup({
+  completion = {
+    autocomplete = false,
+  },
+  mapping = {
+    ["<C-Space>"] = cmp.mapping.complete(),
+    ["<C-n>"] = cmp.mapping.select_next_item(),
+    ["<C-p>"] = cmp.mapping.select_prev_item(),
+    ['<C-b>'] = cmp.mapping.scroll_docs(-4),
+    ['<C-f>'] = cmp.mapping.scroll_docs(4),
+    ['<C-e>'] = cmp.mapping.abort(),
+    ['<CR>'] = cmp.mapping.confirm({ select = true }),
+  },
+  snippet = {
+    expand = function(args)
+      require("luasnip").lsp_expand(args.body)
+    end,
+  },
+  sources = cmp.config.sources({
+    { name = "nvim_lsp" },
+  }),
+})
 
 -- nvim-lspconfig
 local opts = { noremap=true, silent=true }
@@ -48,7 +82,7 @@ vim.keymap.set('n', '[d', vim.diagnostic.goto_prev, opts)
 vim.keymap.set('n', ']d', vim.diagnostic.goto_next, opts)
 
 local on_attach = function(client, bufnr)
-  vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+  vim.api.nvim_buf_set_option(bufnr, "omnifunc", "v:lua.vim.lsp.omnifunc")
 
   local bufopts = { noremap=true, silent=true, buffer=bufnr }
   vim.keymap.set('n', '<leader>f', vim.lsp.buf.formatting, bufopts)
@@ -60,26 +94,27 @@ local on_attach = function(client, bufnr)
 end
 
 require'lspconfig'.solargraph.setup({
-    on_attach = on_attach,
-  })
+  on_attach = on_attach,
+})
 require'lspconfig'.tsserver.setup({
-    on_attach = on_attach,
-  })
+  on_attach = on_attach,
+})
 require'lspconfig'.eslint.setup({
-    on_attach = on_attach,
-  })
+  on_attach = on_attach,
+})
 require'lspconfig'.tailwindcss.setup({
-    on_attach = on_attach,
-  })
+  on_attach = on_attach,
+})
 require'lspconfig'.jsonls.setup({
-    on_attach = on_attach,
-  })
-require'lspconfig'.rust_analyzer.setup({
-    on_attach = on_attach,
-  })
+  on_attach = on_attach,
+})
 
--- leap
-require('leap').set_default_keymaps()
+-- rust-tools
+local capabilities = require("cmp_nvim_lsp").default_capabilities(vim.lsp.protocol.make_client_capabilities())
 
--- general
-vim.o.ch = 0
+require("rust-tools").setup({
+  server = {
+    capabilities = capabilities,
+    on_attach = on_attach,
+  }
+})


### PR DESCRIPTION
Adding rust-tools and autocompletion for rust; never used autocomplete for Ruby and FE work but it is now automatically available for languages with LSP configured in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).

ℹ️ For now, Inlay Hints do not show as nicely like vscode but it is usable/useful still. I'll wait for the neovim to adopt [the new LSP spec](https://github.com/neovim/neovim/issues/18086).

### Triggers

- `C-Space` to trigger autocomplete from LS.
- `C-n` and `C-P` to cycle through the list, down and up respectively. 

### References
- https://github.com/hrsh7th/nvim-cmp/wiki/Language-Server-Specific-Samples#rust-with-rust-toolsnvim
- https://sharksforarms.dev/posts/neovim-rust/